### PR TITLE
Don't cache each network's list of members

### DIFF
--- a/cmd/fluitans/main.go
+++ b/cmd/fluitans/main.go
@@ -32,6 +32,6 @@ func main() {
 	s.Register(e)
 
 	// Start server
-	s.LaunchBackgroundWorkers()
+	go s.RunBackgroundWorkers()
 	e.Logger.Fatal(e.Start(fmt.Sprintf(":%d", port)))
 }

--- a/internal/app/fluitans/client/globals.go
+++ b/internal/app/fluitans/client/globals.go
@@ -16,8 +16,9 @@ import (
 
 type Clients struct {
 	Authn         *authn.Client
-	Desec         *desec.Client
 	Sessions      *session.Client
+
+	Desec         *desec.Client
 	Zerotier      *zerotier.Client
 	ZTControllers *ztcontrollers.Client
 }
@@ -44,17 +45,17 @@ func NewGlobals(l godest.Logger) (g *Globals, err error) {
 	}
 	g.Clients.Authn = authn.NewClient(authnConfig)
 
-	desecConfig, err := desec.GetConfig(g.Config.DomainName)
-	if err != nil {
-		return nil, errors.Wrap(err, "couldn't set up desec config")
-	}
-	g.Clients.Desec = desec.NewClient(desecConfig, g.Cache, l)
-
 	sessionsConfig, err := session.GetConfig()
 	if err != nil {
 		return nil, errors.Wrap(err, "couldn't set up sessions config")
 	}
 	g.Clients.Sessions = session.NewMemStoreClient(sessionsConfig)
+
+	desecConfig, err := desec.GetConfig(g.Config.DomainName)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't set up desec config")
+	}
+	g.Clients.Desec = desec.NewClient(desecConfig, g.Cache, l)
 
 	ztConfig, err := zerotier.GetConfig()
 	if err != nil {

--- a/internal/app/fluitans/client/globals.go
+++ b/internal/app/fluitans/client/globals.go
@@ -15,8 +15,8 @@ import (
 )
 
 type Clients struct {
-	Authn         *authn.Client
-	Sessions      *session.Client
+	Authn    *authn.Client
+	Sessions *session.Client
 
 	Desec         *desec.Client
 	Zerotier      *zerotier.Client

--- a/internal/app/fluitans/workers/dns.go
+++ b/internal/app/fluitans/workers/dns.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sargassum-world/fluitans/internal/clients/desec"
 )
 
-func PrefetchDNSRecords(c *desec.Client) {
+func PrefetchDNSRecords(c *desec.Client) error {
 	const retryInterval = 5000
 	for {
 		if _, err := c.GetRRsets(context.Background()); err != nil {
@@ -21,9 +21,10 @@ func PrefetchDNSRecords(c *desec.Client) {
 
 		break
 	}
+	return nil
 }
 
-func TestWriteLimiter(c *desec.Client) {
+func TestWriteLimiter(c *desec.Client) error {
 	const writeInterval = 5000
 	writeLimiter := c.WriteLimiter
 	for {

--- a/internal/clients/zerotier/networks.go
+++ b/internal/clients/zerotier/networks.go
@@ -190,19 +190,6 @@ func (c *Client) GetNetwork(
 	return c.getNetworkFromZerotier(ctx, controller, id)
 }
 
-func (c *Client) getNetworkMemberAddressesFromCache(networkID string) []string {
-	addresses, err := c.Cache.GetNetworkMembersByID(networkID)
-	if err != nil {
-		// Log the error but return as a cache miss so we can manually query the member addresses
-		c.Logger.Error(errors.Wrapf(
-			err, "couldn't get the cache entry for the member addresses of network %s", networkID,
-		))
-		return nil // treat an unparseable cache entry like a cache miss
-	}
-
-	return addresses // addresses may be nil, which indicates a cache miss
-}
-
 func (c *Client) getNetworkMemberAddressesFromZerotier(
 	ctx context.Context, controller ztcontrollers.Controller, id string,
 ) ([]string, error) {
@@ -236,9 +223,8 @@ func (c *Client) getNetworkMemberAddressesFromZerotier(
 func (c *Client) GetNetworkMemberAddresses(
 	ctx context.Context, controller ztcontrollers.Controller, id string,
 ) ([]string, error) {
-	if addresses := c.getNetworkMemberAddressesFromCache(id); addresses != nil {
-		return addresses, nil
-	}
+	// We don't look up the addresses from cache, since they can change independently of the cache
+	// (especially when a device uses Zerotier to try to join the network)
 	return c.getNetworkMemberAddressesFromZerotier(ctx, controller, id)
 }
 


### PR DESCRIPTION
This PR fixes a bug in which Fluitans failed to refresh the list of network members (authorized and unauthorized) after a new device attempted to join the network, and the list of network members was only refreshed after Fluitans was restarted. Specifically, this PR removes the Zerotier client's code for looking up the list of network members from the cache, as the cache could not update when a new device attempted to join the network.