### PR TITLE
Add support for the Turbo Streams remove action, add graceful shutdown

### DIFF
--- a/cmd/fluitans/main.go
+++ b/cmd/fluitans/main.go
@@ -2,37 +2,49 @@ package main
 
 import (
 	"context"
-	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
-	"github.com/labstack/gommon/log"
 
 	"github.com/sargassum-world/fluitans/internal/app/fluitans"
 )
 
-const port = 3000
+const shutdownTimeout = 5 // sec
 
 func main() {
-	e := echo.New()
-
-	// Middleware
-	e.Use(middleware.Recover())
-	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
-		Format: "${remote_ip} ${method} ${uri} (${bytes_in}b) => " +
-			"(${bytes_out}b after ${latency_human}) ${status} ${error}\n",
-	}))
-	e.Logger.SetLevel(log.WARN)
-
 	// Prepare server
-	s, err := fluitans.NewServer(e)
+	e := echo.New()
+	server, err := fluitans.NewServer(e.Logger)
 	if err != nil {
-		fmt.Printf("%+v\n", err)
-		panic(err)
+		e.Logger.Fatal(err)
 	}
-	s.Register(e)
+	server.Register(e)
 
-	// Start server
-	go s.RunBackgroundWorkers(context.TODO())
-	e.Logger.Fatal(e.Start(fmt.Sprintf(":%d", port)))
+	// Run server
+	ctxRun, cancelRun := signal.NotifyContext(
+		context.Background(), os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT,
+	)
+	go func() {
+		if err = server.Run(e); err != nil {
+			e.Logger.Error(err)
+		}
+		cancelRun()
+	}()
+	<-ctxRun.Done()
+	cancelRun()
+
+	// Shut down server
+	ctxShutdown, cancelShutdown := context.WithTimeout(
+		context.Background(), shutdownTimeout*time.Second,
+	)
+	defer cancelShutdown()
+	e.Logger.Infof("attempting to shut down gracefully within %d sec", shutdownTimeout)
+	if err := server.Shutdown(ctxShutdown, e); err != nil {
+		e.Logger.Warn("forcibly closing http server due to failure of graceful shutdown")
+		e.Logger.Error(server.Close(e))
+	}
+	e.Logger.Info("finished shutdown")
 }

--- a/internal/app/fluitans/auth/sessions.go
+++ b/internal/app/fluitans/auth/sessions.go
@@ -28,10 +28,6 @@ func GetWithoutRequest(s sessions.Session, ss session.Store) (a Auth, err error)
 
 // HTTP
 
-func Get(r *http.Request, s sessions.Session, ss session.Store) (a Auth, err error) {
-	return GetFromRequest(r, s, ss)
-}
-
 func GetFromRequest(r *http.Request, s sessions.Session, ss session.Store) (a Auth, err error) {
 	a, err = GetWithoutRequest(s, ss)
 	if err != nil {
@@ -56,7 +52,7 @@ func GetWithSession(
 		}
 		// We let the caller save the new session
 	}
-	a, err = Get(r, *s, ss)
+	a, err = GetFromRequest(r, *s, ss)
 	if err != nil {
 		return Auth{}, s, err
 	}

--- a/internal/app/fluitans/handling/time.go
+++ b/internal/app/fluitans/handling/time.go
@@ -1,4 +1,3 @@
-// Package handling provides utilities for handlers
 package handling
 
 import (

--- a/internal/app/fluitans/handling/turbostreams.go
+++ b/internal/app/fluitans/handling/turbostreams.go
@@ -1,3 +1,4 @@
+// Package handling provides utilities for handlers
 package handling
 
 import (
@@ -14,6 +15,17 @@ import (
 func AddAuthData(a auth.Auth, messages []turbostreams.Message) ([]turbostreams.Message, error) {
 	published := make([]turbostreams.Message, len(messages))
 	for i, m := range messages {
+		published[i] = turbostreams.Message{
+			Action:   m.Action,
+			Target:   m.Target,
+			Template: m.Template,
+		}
+		if m.Action == turbostreams.ActionRemove {
+			// The contents of the stream element will be ignored anyways
+			published[i].Template = ""
+			continue
+		}
+
 		d, ok := m.Data.(map[string]interface{})
 		if !ok {
 			return nil, errors.Errorf("unexpected turbo stream message data type: %T", m.Data)
@@ -24,12 +36,7 @@ func AddAuthData(a auth.Auth, messages []turbostreams.Message) ([]turbostreams.M
 			data[key] = value
 		}
 		data["Auth"] = a
-		published[i] = turbostreams.Message{
-			Action:   m.Action,
-			Target:   m.Target,
-			Template: m.Template,
-			Data:     data,
-		}
+		published[i].Data = data
 	}
 	return published, nil
 }

--- a/internal/app/fluitans/routes/auth/sessions.go
+++ b/internal/app/fluitans/routes/auth/sessions.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sargassum-world/fluitans/pkg/godest/session"
 )
 
-type CSRFData struct {
+type CSRFViewData struct {
 	HeaderName string `json:"headerName,omitempty"`
 	FieldName  string `json:"fieldName,omitempty"`
 	Token      string `json:"token,omitempty"`
@@ -25,7 +25,7 @@ func (h *Handlers) HandleCSRFGet() echo.HandlerFunc {
 	return func(c echo.Context) error {
 		// Produce output
 		godest.WithUncacheable()(c.Response().Header())
-		return c.JSON(http.StatusOK, CSRFData{
+		return c.JSON(http.StatusOK, CSRFViewData{
 			HeaderName: h.ss.CSRFOptions().HeaderName,
 			FieldName:  h.ss.CSRFOptions().FieldName,
 			Token:      csrf.Token(c.Request()),
@@ -33,7 +33,7 @@ func (h *Handlers) HandleCSRFGet() echo.HandlerFunc {
 	}
 }
 
-type LoginData struct {
+type LoginViewData struct {
 	NoAuth        bool
 	ReturnURL     string
 	ErrorMessages []string
@@ -48,7 +48,7 @@ func (h *Handlers) HandleLoginGet() auth.HTTPHandlerFuncWithSession {
 		if err != nil {
 			return err
 		}
-		loginData := LoginData{
+		loginViewData := LoginViewData{
 			NoAuth:        h.ac.Config.NoAuth,
 			ReturnURL:     c.QueryParam("return"),
 			ErrorMessages: errorMessages,
@@ -61,7 +61,7 @@ func (h *Handlers) HandleLoginGet() auth.HTTPHandlerFuncWithSession {
 		a.CSRF.SetInlining(c.Request(), true)
 
 		// Produce output
-		return h.r.CacheablePage(c.Response(), c.Request(), t, loginData, a)
+		return h.r.CacheablePage(c.Response(), c.Request(), t, loginViewData, a)
 	}
 }
 

--- a/internal/app/fluitans/routes/controllers/controller.go
+++ b/internal/app/fluitans/routes/controllers/controller.go
@@ -13,16 +13,16 @@ import (
 	"github.com/sargassum-world/fluitans/pkg/zerotier"
 )
 
-type ControllerData struct {
+type ControllerViewData struct {
 	Controller       ztcontrollers.Controller
 	Status           zerotier.Status
 	ControllerStatus zerotier.ControllerStatus
 	Networks         map[string]zerotier.ControllerNetwork
 }
 
-func getControllerData(
+func getControllerViewData(
 	ctx context.Context, name string, cc *ztcontrollers.Client, c *ztc.Client,
-) (*ControllerData, error) {
+) (*ControllerViewData, error) {
 	controller, err := cc.FindController(name)
 	if err != nil {
 		return nil, err
@@ -45,7 +45,7 @@ func getControllerData(
 		return nil, err
 	}
 
-	return &ControllerData{
+	return &ControllerViewData{
 		Controller:       *controller,
 		Status:           *status,
 		ControllerStatus: *controllerStatus,
@@ -61,15 +61,15 @@ func (h *Handlers) HandleControllerGet() auth.HTTPHandlerFunc {
 		name := c.Param("name")
 
 		// Run queries
-		controllerData, err := getControllerData(c.Request().Context(), name, h.ztcc, h.ztc)
+		controllerViewData, err := getControllerViewData(c.Request().Context(), name, h.ztcc, h.ztc)
 		if err != nil {
 			return err
 		}
 
 		// Produce output
 		// Zero out clocks before computing etag for client-side caching
-		*controllerData.Status.Clock = 0
-		*controllerData.ControllerStatus.Clock = 0
-		return h.r.CacheablePage(c.Response(), c.Request(), t, *controllerData, a)
+		*controllerViewData.Status.Clock = 0
+		*controllerViewData.ControllerStatus.Clock = 0
+		return h.r.CacheablePage(c.Response(), c.Request(), t, *controllerViewData, a)
 	}
 }

--- a/internal/app/fluitans/routes/controllers/routes.go
+++ b/internal/app/fluitans/routes/controllers/routes.go
@@ -10,7 +10,8 @@ import (
 )
 
 type Handlers struct {
-	r    godest.TemplateRenderer
+	r godest.TemplateRenderer
+
 	ztcc *ztcontrollers.Client
 	ztc  *zerotier.Client
 }

--- a/internal/app/fluitans/routes/dns/routes.go
+++ b/internal/app/fluitans/routes/dns/routes.go
@@ -33,12 +33,12 @@ func New(
 }
 
 func (h *Handlers) Register(er godest.EchoRouter, tsr turbostreams.Router, ss session.Store) {
-	ar := auth.NewHTTPRouter(er, ss)
-	az := auth.RequireHTTPAuthz(ss)
-	atsz := auth.RequireTSAuthz(ss)
-	ar.GET("/dns", h.HandleServerGet(), az)
-	tsr.SUB("/dns/server/info", turbostreams.EmptyHandler, atsz)
+	hr := auth.NewHTTPRouter(er, ss)
+	haz := auth.RequireHTTPAuthz(ss)
+	tsaz := auth.RequireTSAuthz(ss)
+	hr.GET("/dns", h.HandleServerGet(), haz)
+	tsr.SUB("/dns/server/info", turbostreams.EmptyHandler, tsaz)
 	tsr.PUB("/dns/server/info", h.HandleServerInfoPub())
-	tsr.MSG("/dns/server/info", handling.HandleTSMsg(h.r, ss), atsz)
-	er.POST("/dns/:subname/:type", h.HandleRRsetPost(), az)
+	tsr.MSG("/dns/server/info", handling.HandleTSMsg(h.r, ss), tsaz)
+	er.POST("/dns/:subname/:type", h.HandleRRsetPost(), haz)
 }

--- a/internal/app/fluitans/routes/dns/server.go
+++ b/internal/app/fluitans/routes/dns/server.go
@@ -26,7 +26,7 @@ type APILimiterStats struct {
 	WriteBatchWaitSec      float64
 }
 
-type ServerData struct {
+type ServerView struct {
 	Server           models.DNSServer
 	Domain           desec.Domain
 	DesecAPISettings desecc.DesecAPISettings
@@ -48,9 +48,9 @@ func getAPILimiterStats(c *desecc.Client) APILimiterStats {
 	}
 }
 
-func getServerData(
+func getServerView(
 	ctx context.Context, c *desecc.Client, zc *ztc.Client, zcc *ztcontrollers.Client,
-) (*ServerData, error) {
+) (*ServerView, error) {
 	desecDomain, err := c.GetDomain(ctx)
 	if err != nil {
 		return nil, err
@@ -68,7 +68,7 @@ func getServerData(
 		return nil, err
 	}
 
-	return &ServerData{
+	return &ServerView{
 		Server:           c.Config.DNSServer,
 		Domain:           *desecDomain,
 		DesecAPISettings: c.Config.APISettings,
@@ -83,13 +83,13 @@ func (h *Handlers) HandleServerGet() auth.HTTPHandlerFunc {
 	h.r.MustHave(t)
 	return func(c echo.Context, a auth.Auth) error {
 		// Run queries
-		serverData, err := getServerData(c.Request().Context(), h.dc, h.ztc, h.ztcc)
+		serverView, err := getServerView(c.Request().Context(), h.dc, h.ztc, h.ztcc)
 		if err != nil {
 			return err
 		}
 
 		// Produce output
-		return h.r.CacheablePage(c.Response(), c.Request(), t, *serverData, a)
+		return h.r.CacheablePage(c.Response(), c.Request(), t, *serverView, a)
 	}
 }
 

--- a/internal/app/fluitans/routes/networks/devices.go
+++ b/internal/app/fluitans/routes/networks/devices.go
@@ -67,7 +67,7 @@ func replaceDevicesListStream(
 	ctx context.Context, controllerAddress, networkID string, a auth.Auth,
 	c *ztc.Client, cc *ztcontrollers.Client, dc *desec.Client,
 ) (turbostreams.Message, error) {
-	networkData, err := getNetworkData(ctx, controllerAddress, networkID, c, cc, dc)
+	networkViewData, err := getNetworkViewData(ctx, controllerAddress, networkID, c, cc, dc)
 	if err != nil {
 		return turbostreams.Message{}, err
 	}
@@ -76,9 +76,9 @@ func replaceDevicesListStream(
 		Target:   "/networks/" + networkID + "/devices",
 		Template: devicesListPartial,
 		Data: map[string]interface{}{
-			"Members":    networkData.Members,
-			"Network":    networkData.Network,
-			"NetworkDNS": networkData.NetworkDNS,
+			"Members":    networkViewData.Members,
+			"Network":    networkViewData.Network,
+			"NetworkDNS": networkViewData.NetworkDNS,
 			"Auth":       a,
 		},
 	}, nil

--- a/internal/app/fluitans/routes/networks/network.go
+++ b/internal/app/fluitans/routes/networks/network.go
@@ -219,7 +219,7 @@ func getNetworkDNSRecords(
 	return networkDNS, nil
 }
 
-type NetworkData struct {
+type NetworkViewData struct {
 	Controller       ztcontrollers.Controller
 	Network          zerotier.ControllerNetwork
 	Members          map[string]Member
@@ -236,10 +236,10 @@ func printJSONRules(rawRules []map[string]interface{}) (string, error) {
 	return string(rules), err
 }
 
-func getNetworkData(
+func getNetworkViewData(
 	ctx context.Context, address, id string,
 	c *ztc.Client, cc *ztcontrollers.Client, dc *desecc.Client,
-) (*NetworkData, error) {
+) (*NetworkViewData, error) {
 	controller, err := cc.FindControllerByAddress(ctx, address)
 	if err != nil {
 		return nil, err
@@ -287,7 +287,7 @@ func getNetworkData(
 		return nil, err
 	}
 
-	return &NetworkData{
+	return &NetworkViewData{
 		Controller:       *controller,
 		Network:          *network,
 		Members:          members,
@@ -306,13 +306,15 @@ func (h *Handlers) HandleNetworkGet() auth.HTTPHandlerFunc {
 		address := ztc.GetControllerAddress(id)
 
 		// Run queries
-		networkData, err := getNetworkData(c.Request().Context(), address, id, h.ztc, h.ztcc, h.dc)
+		networkViewData, err := getNetworkViewData(
+			c.Request().Context(), address, id, h.ztc, h.ztcc, h.dc,
+		)
 		if err != nil {
 			return err
 		}
 
 		// Produce output
-		return h.r.CacheablePage(c.Response(), c.Request(), t, *networkData, a)
+		return h.r.CacheablePage(c.Response(), c.Request(), t, *networkViewData, a)
 	}
 }
 

--- a/internal/app/fluitans/routes/networks/network.go
+++ b/internal/app/fluitans/routes/networks/network.go
@@ -239,11 +239,15 @@ func printJSONRules(rawRules []map[string]interface{}) (string, error) {
 func getNetworkViewData(
 	ctx context.Context, address, id string,
 	c *ztc.Client, cc *ztcontrollers.Client, dc *desecc.Client,
-) (*NetworkViewData, error) {
+) (vd NetworkViewData, err error) {
 	controller, err := cc.FindControllerByAddress(ctx, address)
 	if err != nil {
-		return nil, err
+		return NetworkViewData{}, err
 	}
+	if controller == nil {
+		return NetworkViewData{}, echo.NewHTTPError(http.StatusNotFound, "controller not found")
+	}
+	vd.Controller = *controller
 
 	eg, egctx := errgroup.WithContext(ctx)
 	var network *zerotier.ControllerNetwork
@@ -258,43 +262,36 @@ func getNetworkViewData(
 		return err
 	})
 	if err = eg.Wait(); err != nil {
-		return nil, err
+		return NetworkViewData{}, err
 	}
 	if network == nil {
-		return nil, echo.NewHTTPError(http.StatusNotFound, "zerotier network not found")
+		return NetworkViewData{}, echo.NewHTTPError(http.StatusNotFound, "zerotier network not found")
 	}
-	rules, err := printJSONRules(*network.Rules)
-	if err != nil {
-		return nil, err
+	vd.Network = *network
+	if vd.JSONPrintedRules, err = printJSONRules(*network.Rules); err != nil {
+		return NetworkViewData{}, err
 	}
 
 	eg, egctx = errgroup.WithContext(ctx)
-	var members map[string]Member
 	eg.Go(func() (err error) {
-		members, err = getMemberRecords(
+		vd.Members, err = getMemberRecords(
 			ctx, dc.Config.DomainName, *controller, *network, memberAddresses, subnameRRsets, c,
 		)
 		return err
 	})
-	var networkDNS NetworkDNS
 	eg.Go(func() (err error) {
-		networkDNS, err = getNetworkDNSRecords(
+		vd.NetworkDNS, err = getNetworkDNSRecords(
 			egctx, *network.Id, *network.Name, subnameRRsets, c, cc, dc,
 		)
 		return err
 	})
 	if err := eg.Wait(); err != nil {
-		return nil, err
+		return NetworkViewData{}, err
 	}
 
-	return &NetworkViewData{
-		Controller:       *controller,
-		Network:          *network,
-		Members:          members,
-		JSONPrintedRules: rules,
-		DomainName:       dc.Config.DomainName,
-		NetworkDNS:       networkDNS,
-	}, nil
+	vd.DomainName = dc.Config.DomainName
+
+	return vd, nil
 }
 
 func (h *Handlers) HandleNetworkGet() auth.HTTPHandlerFunc {
@@ -314,7 +311,7 @@ func (h *Handlers) HandleNetworkGet() auth.HTTPHandlerFunc {
 		}
 
 		// Produce output
-		return h.r.CacheablePage(c.Response(), c.Request(), t, *networkViewData, a)
+		return h.r.CacheablePage(c.Response(), c.Request(), t, networkViewData, a)
 	}
 }
 

--- a/internal/app/fluitans/routes/networks/networks.go
+++ b/internal/app/fluitans/routes/networks/networks.go
@@ -13,14 +13,14 @@ import (
 	"github.com/sargassum-world/fluitans/pkg/zerotier"
 )
 
-type NetworksData struct {
+type NetworksViewData struct {
 	Controller ztcontrollers.Controller
 	Networks   map[string]zerotier.ControllerNetwork
 }
 
-func getNetworksData(
+func getNetworksViewData(
 	ctx context.Context, c *ztc.Client, cc *ztcontrollers.Client,
-) ([]NetworksData, error) {
+) ([]NetworksViewData, error) {
 	controllers, err := cc.GetControllers()
 	if err != nil {
 		return nil, err
@@ -36,12 +36,12 @@ func getNetworksData(
 		return nil, err
 	}
 
-	networksData := make([]NetworksData, len(controllers))
+	networksViewData := make([]NetworksViewData, len(controllers))
 	for i, controller := range controllers {
-		networksData[i].Controller = controller
-		networksData[i].Networks = networks[i]
+		networksViewData[i].Controller = controller
+		networksViewData[i].Networks = networks[i]
 	}
-	return networksData, nil
+	return networksViewData, nil
 }
 
 func (h *Handlers) HandleNetworksGet() auth.HTTPHandlerFunc {
@@ -49,13 +49,13 @@ func (h *Handlers) HandleNetworksGet() auth.HTTPHandlerFunc {
 	h.r.MustHave(t)
 	return func(c echo.Context, a auth.Auth) error {
 		// Run queries
-		networksData, err := getNetworksData(c.Request().Context(), h.ztc, h.ztcc)
+		networksViewData, err := getNetworksViewData(c.Request().Context(), h.ztc, h.ztcc)
 		if err != nil {
 			return err
 		}
 
 		// Produce output
-		return h.r.CacheablePage(c.Response(), c.Request(), t, networksData, a)
+		return h.r.CacheablePage(c.Response(), c.Request(), t, networksViewData, a)
 	}
 }
 

--- a/internal/app/fluitans/routes/networks/routes.go
+++ b/internal/app/fluitans/routes/networks/routes.go
@@ -38,7 +38,7 @@ func New(
 func (h *Handlers) Register(er godest.EchoRouter, tsr turbostreams.Router, ss session.Store) {
 	hr := auth.NewHTTPRouter(er, ss)
 	haz := auth.RequireHTTPAuthz(ss)
-	atsz := auth.RequireTSAuthz(ss)
+	tsaz := auth.RequireTSAuthz(ss)
 	hr.GET("/networks", h.HandleNetworksGet())
 	er.POST("/networks", h.HandleNetworksPost(), haz)
 	hr.GET("/networks/:id", h.HandleNetworkGet())
@@ -46,9 +46,9 @@ func (h *Handlers) Register(er godest.EchoRouter, tsr turbostreams.Router, ss se
 	er.POST("/networks/:id/name", h.HandleNetworkNamePost(), haz)
 	hr.POST("/networks/:id/rules", h.HandleNetworkRulesPost(), haz)
 	hr.POST("/networks/:id/devices", h.HandleDevicesPost(), haz)
-	tsr.SUB("/networks/:id/devices", h.HandleDevicesSub(), atsz)
+	tsr.SUB("/networks/:id/devices", h.HandleDevicesSub(), tsaz)
 	tsr.PUB("/networks/:id/devices", h.HandleDevicesPub())
-	tsr.MSG("/networks/:id/devices", handling.HandleTSMsg(h.r, ss), atsz)
+	tsr.MSG("/networks/:id/devices", handling.HandleTSMsg(h.r, ss), tsaz)
 	hr.POST("/networks/:id/devices/:address/authorization", h.HandleDeviceAuthorizationPost(), haz)
 	hr.POST("/networks/:id/devices/:address/name", h.HandleDeviceNamePost(), haz)
 }

--- a/internal/app/fluitans/server.go
+++ b/internal/app/fluitans/server.go
@@ -4,12 +4,14 @@ package fluitans
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/gorilla/csrf"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"github.com/labstack/gommon/log"
 	"github.com/pkg/errors"
 	"github.com/unrolled/secure"
 	"golang.org/x/sync/errgroup"
@@ -32,9 +34,9 @@ type Server struct {
 	Handlers *routes.Handlers
 }
 
-func NewServer(e *echo.Echo) (s *Server, err error) {
+func NewServer(logger godest.Logger) (s *Server, err error) {
 	s = &Server{}
-	s.Globals, err = client.NewGlobals(e.Logger)
+	s.Globals, err = client.NewGlobals(logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "couldn't make app globals")
 	}
@@ -55,8 +57,19 @@ func NewServer(e *echo.Echo) (s *Server, err error) {
 	return s, nil
 }
 
-func (s *Server) Register(e *echo.Echo) {
-	// HTTP Headers Middleware
+// Echo
+
+func (s *Server) configureLogging(e *echo.Echo) {
+	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
+		Format: "${remote_ip} ${method} ${uri} (${bytes_in}b) => " +
+			"(${bytes_out}b after ${latency_human}) ${status} ${error}\n",
+	}))
+	e.HideBanner = true
+	e.HidePort = true
+	e.Logger.SetLevel(log.INFO) // TODO: set level via env var
+}
+
+func (s *Server) configureHeaders(e *echo.Echo) {
 	csp := strings.Join([]string{
 		"default-src 'self'",
 		// Warning: script-src 'self' may not be safe to use if we're hosting user-uploaded content.
@@ -91,6 +104,12 @@ func (s *Server) Register(e *echo.Echo) {
 	}).Handler))
 	e.Use(echo.WrapMiddleware(gmw.SetCORP("same-site")))
 	e.Use(echo.WrapMiddleware(gmw.SetCOEP("require-corp")))
+}
+
+func (s *Server) Register(e *echo.Echo) {
+	e.Use(middleware.Recover())
+	s.configureLogging(e)
+	s.configureHeaders(e)
 
 	// Compression Middleware
 	e.Use(middleware.Decompress())
@@ -111,27 +130,79 @@ func (s *Server) Register(e *echo.Echo) {
 	s.Handlers.Register(e, s.Globals.TSBroker, s.Embeds)
 }
 
-func (s *Server) RunBackgroundWorkers(ctx context.Context) {
+// Running
+
+func (s *Server) runWorkersInContext(ctx context.Context) error {
 	eg, _ := errgroup.WithContext(ctx) // Workers run independently, so we don't need egctx
 	eg.Go(func() error {
-		return workers.PrescanZerotierControllers(ctx, s.Globals.ZTControllers)
+		if err := workers.PrescanZerotierControllers(ctx, s.Globals.ZTControllers); err != nil {
+			s.Globals.Logger.Error(errors.Wrap(err, "couldn't prescan zerotier controllers"))
+		}
+		return nil
 	})
 	eg.Go(func() error {
-		return workers.PrefetchZerotierNetworks(
+		if err := workers.PrefetchZerotierNetworks(
 			ctx, s.Globals.Zerotier, s.Globals.ZTControllers,
-		)
+		); err != nil {
+			s.Globals.Logger.Error(errors.Wrap(err, "couldn't prefetch zerotier networks"))
+		}
+		return nil
 	})
 	eg.Go(func() error {
-		return workers.PrefetchDNSRecords(ctx, s.Globals.Desec)
+		if err := workers.PrefetchDNSRecords(ctx, s.Globals.Desec); err != nil {
+			s.Globals.Logger.Error(errors.Wrap(err, "couldn't prefetch dns records"))
+		}
+		return nil
 	})
-	// TODO: replace with a worker to batch DNS record writes when needed
-	/*eg.Go(func() error {
-		return workers.TestWriteLimiter(ctx, s.Globals.Desec)
-	})*/
+	// TODO: add worker to batch DNS record writes when needed
 	eg.Go(func() error {
-		return s.Globals.TSBroker.Serve(ctx)
+		if err := s.Globals.TSBroker.Serve(ctx); err != nil && err != context.Canceled {
+			s.Globals.Logger.Error(errors.Wrap(
+				err, "turbo streams broker encountered error while serving",
+			))
+		}
+		return nil
 	})
-	if err := eg.Wait(); err != nil {
-		s.Globals.Logger.Error(err)
+	return eg.Wait()
+}
+
+const port = 3000 // TODO: configure this with env var
+
+func (s *Server) Run(e *echo.Echo) error {
+	s.Globals.Logger.Info("starting fluitans server")
+	// The echo http server can't be canceled by context cancelation, so the API shouldn't promise to
+	// stop blocking execution on context cancelation - so we use the background context here. The
+	// http server should instead be stopped gracefully by calling the Shutdown method, or forcefully
+	// by calling the Close method.
+	eg, egctx := errgroup.WithContext(context.Background())
+	eg.Go(func() error {
+		s.Globals.Logger.Info("starting background workers")
+		if err := s.runWorkersInContext(egctx); err != nil {
+			s.Globals.Logger.Error(errors.Wrap(
+				err, "background worker encountered error",
+			))
+		}
+		return nil
+	})
+	eg.Go(func() error {
+		address := fmt.Sprintf(":%d", port)
+		s.Globals.Logger.Infof("starting http server on %s", address)
+		return e.Start(address)
+	})
+	if err := eg.Wait(); err != http.ErrServerClosed {
+		return errors.Wrap(err, "http server encountered error")
 	}
+	return nil
+}
+
+func (s *Server) Shutdown(ctx context.Context, e *echo.Echo) (err error) {
+	if errEcho := e.Shutdown(ctx); errEcho != nil {
+		s.Globals.Logger.Error(errors.Wrap(errEcho, "couldn't shut down http server"))
+		err = errEcho
+	}
+	return err
+}
+
+func (s *Server) Close(e *echo.Echo) error {
+	return errors.Wrap(e.Close(), "http server encountered error when closing an underlying listener")
 }

--- a/pkg/godest/actioncable/connections.go
+++ b/pkg/godest/actioncable/connections.go
@@ -244,8 +244,10 @@ func (c *Conn) receiveAll(ctx context.Context) (err error) {
 		var command clientMessage
 		received := make(chan interface{})
 		go func() {
-			// ReadJSON blocks for a while due to websocke read timeout, but we don't want it to delay
+			// ReadJSON blocks for a while due to websocket read timeout, but we don't want it to delay
 			// context cancellation so we launch it and synchronize with a closable channel
+			// FIXME: there's a rare data race in which ReadJSON may try to write to the websocket
+			// at the same time that something happens in the select.
 			err = c.wsc.ReadJSON(&command)
 			close(received)
 		}()

--- a/pkg/godest/pubsub/hub.go
+++ b/pkg/godest/pubsub/hub.go
@@ -33,6 +33,10 @@ func NewDataHub(brChanges chan<- BroadcastingChange) *DataHub {
 	}
 }
 
+func (h *DataHub) Shutdown() {
+	close(h.brChanges)
+}
+
 func (h *DataHub) Subscribe(
 	topic string, receive DataReceiveFunc,
 ) (unsubscriber func(), removed <-chan struct{}) {

--- a/pkg/godest/pubsub/hub.go
+++ b/pkg/godest/pubsub/hub.go
@@ -33,8 +33,12 @@ func NewDataHub(brChanges chan<- BroadcastingChange) *DataHub {
 	}
 }
 
-func (h *DataHub) Shutdown() {
-	close(h.brChanges)
+func (h *DataHub) Close() {
+	if h.brChanges != nil {
+		close(h.brChanges)
+	}
+	// FIXME: we should also prevent further subscriptions and publications, unsubscribe everyone,
+	// etc.
 }
 
 func (h *DataHub) Subscribe(

--- a/pkg/godest/pubsub/strings.go
+++ b/pkg/godest/pubsub/strings.go
@@ -10,8 +10,8 @@ func NewStringHub(brChanges chan<- BroadcastingChange) *StringHub {
 	return &StringHub{hub: NewDataHub(brChanges)}
 }
 
-func (h *StringHub) Shutdown() {
-	h.hub.Shutdown()
+func (h *StringHub) Close() {
+	h.hub.Close()
 }
 
 func (h *StringHub) Subscribe(

--- a/pkg/godest/pubsub/strings.go
+++ b/pkg/godest/pubsub/strings.go
@@ -10,6 +10,10 @@ func NewStringHub(brChanges chan<- BroadcastingChange) *StringHub {
 	return &StringHub{hub: NewDataHub(brChanges)}
 }
 
+func (h *StringHub) Shutdown() {
+	h.hub.Shutdown()
+}
+
 func (h *StringHub) Subscribe(
 	topic string, receive StringReceiveFunc,
 ) (unsubscriber func(), removed <-chan struct{}) {

--- a/pkg/godest/turbostreams/broker.go
+++ b/pkg/godest/turbostreams/broker.go
@@ -189,7 +189,7 @@ func (b *Broker) cancelPub(topic string) {
 func (b *Broker) Serve(ctx stdContext.Context) error {
 	go func() {
 		<-ctx.Done()
-		b.hub.Shutdown()
+		b.hub.Close()
 	}()
 	for change := range b.changes {
 		for _, topic := range change.Added {

--- a/pkg/godest/turbostreams/broker.go
+++ b/pkg/godest/turbostreams/broker.go
@@ -187,6 +187,10 @@ func (b *Broker) cancelPub(topic string) {
 }
 
 func (b *Broker) Serve(ctx stdContext.Context) error {
+	go func() {
+		<-ctx.Done()
+		b.hub.Shutdown()
+	}()
 	for change := range b.changes {
 		for _, topic := range change.Added {
 			if _, ok := b.pubCancellers[topic]; ok {
@@ -198,5 +202,5 @@ func (b *Broker) Serve(ctx stdContext.Context) error {
 			b.cancelPub(topic)
 		}
 	}
-	return nil
+	return ctx.Err()
 }

--- a/pkg/godest/turbostreams/pubsub.go
+++ b/pkg/godest/turbostreams/pubsub.go
@@ -14,8 +14,8 @@ func NewMessagesHub(brChanges chan<- pubsub.BroadcastingChange) *MessagesHub {
 	return &MessagesHub{hub: pubsub.NewDataHub(brChanges)}
 }
 
-func (h *MessagesHub) Shutdown() {
-	h.hub.Shutdown()
+func (h *MessagesHub) Close() {
+	h.hub.Close()
 }
 
 func (h *MessagesHub) Subscribe(

--- a/pkg/godest/turbostreams/pubsub.go
+++ b/pkg/godest/turbostreams/pubsub.go
@@ -14,6 +14,10 @@ func NewMessagesHub(brChanges chan<- pubsub.BroadcastingChange) *MessagesHub {
 	return &MessagesHub{hub: pubsub.NewDataHub(brChanges)}
 }
 
+func (h *MessagesHub) Shutdown() {
+	h.hub.Shutdown()
+}
+
 func (h *MessagesHub) Subscribe(
 	topic string, receive MessagesReceiveFunc,
 ) (unsubscriber func(), removed <-chan struct{}) {

--- a/web/templates/shared/base.layout.tmpl
+++ b/web/templates/shared/base.layout.tmpl
@@ -27,6 +27,7 @@
   >
   <script>{{.Inlines.JS.BundleEager}}</script>
   {{block "nav/navbar.assets" .}}{{end}}
+  <!-- crossorigin is needed to preload fonts correctly -->
   <link
     rel="preload"
     as="font"


### PR DESCRIPTION
This PR adds some improvements. Specifically, it
- Adds support for template-less and data-less Turbo Streams remove actions to the godest framework and the internal `handling.AddAuthData` turbostreams handler helper function.
- Adds graceful shutdown support to the fluitans server.

This PR also includes some refactoring. Specifically, it:
- Renames the data structs for templates into "ViewData" structs, and makes the helper functions to get such structs return the structs themselves, rather than returning pointers to the structs.
- Renames the custom routers to have more consistent abbreviated names.
- Removes the redundant internal `auth.Get` function.