### PR TITLE
Add turbostreams context method accessor to the Context interface

### DIFF
--- a/pkg/godest/turbostreams/broker-context.go
+++ b/pkg/godest/turbostreams/broker-context.go
@@ -8,6 +8,7 @@ import (
 
 type Context interface {
 	Context() stdContext.Context
+	Method() string
 	Topic() string
 	SessionID() string
 	Param(name string) string


### PR DESCRIPTION
This PR fixes an issue in #52 where the Turbostreams Context interface did not include the `Method()` method which was added by that PR to the private `context` type.