### PR TITLE
Avoid logging context cancelation errors in the Turbo Streams Broker

### DIFF
--- a/internal/clients/desec/domain.go
+++ b/internal/clients/desec/domain.go
@@ -13,7 +13,7 @@ import (
 func (c *Client) getDomainFromCache() (*desec.Domain, bool) {
 	domainName := c.Config.DomainName
 	domain, cacheHit, err := c.Cache.GetDomainByName(domainName)
-	if err != nil && err != context.Canceled && errors.Unwrap(err) != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		// Log the error but return as a cache miss so we can manually query the domain
 		c.Logger.Error(errors.Wrapf(
 			err, "couldn't get the cache entry for the domain with name %s", domainName,

--- a/internal/clients/desec/rrsets.go
+++ b/internal/clients/desec/rrsets.go
@@ -42,7 +42,7 @@ func FilterAndSortRRsets(rrsets []desec.RRset, recordTypes []string) []desec.RRs
 func (c *Client) getRRsetsFromCache() map[string][]desec.RRset {
 	domainName := c.Config.DomainName
 	subnames, err := c.Cache.GetSubnames(domainName)
-	if err != nil && err != context.Canceled && errors.Unwrap(err) != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		// Log the error but return as a cache miss so we can manually query the RRsets
 		c.Logger.Error(errors.Wrapf(
 			err, "couldn't get the cache entry for the RRsets for %s", domainName,
@@ -126,7 +126,7 @@ func (c *Client) GetRRsets(ctx context.Context) (map[string][]desec.RRset, error
 func (c *Client) getSubnameRRsetsFromCache(subname string) []desec.RRset {
 	domainName := c.Config.DomainName
 	rrsets, err := c.Cache.GetRRsetsByName(domainName, subname)
-	if err != nil && err != context.Canceled && errors.Unwrap(err) != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		// Log the error but return as a cache miss so we can manually query the RRsets
 		c.Logger.Error(errors.Wrapf(
 			err, "couldn't get the cache entry for one of the RRsets for %s.%s", subname, domainName,
@@ -184,7 +184,7 @@ func (c *Client) GetSubnameRRsets(ctx context.Context, subname string) ([]desec.
 func (c *Client) getRRsetFromCache(subname, recordType string) (*desec.RRset, bool) {
 	domainName := c.Config.DomainName
 	rrset, cacheHit, err := c.Cache.GetRRsetByNameAndType(domainName, subname, recordType)
-	if err != nil && err != context.Canceled && errors.Unwrap(err) != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		// Log the error but return as a cache miss so we can manually query the RRsets
 		c.Logger.Error(errors.Wrapf(
 			err, "couldn't get the cache entry for the %s RRsets for %s.%s",

--- a/internal/clients/zerotier/networks.go
+++ b/internal/clients/zerotier/networks.go
@@ -23,7 +23,7 @@ func (c *Client) getNetworkIDsFromCache(
 	controller ztcontrollers.Controller, cc *ztcontrollers.Client,
 ) []string {
 	networkIDs, err := cc.Cache.GetNetworkIDsByServer(controller.Server)
-	if err != nil && err != context.Canceled && errors.Unwrap(err) != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		// Log the error but return as a cache miss so we can manually query the network IDs
 		c.Logger.Error(errors.Wrapf(
 			err, "couldn't get the cache entry for the network IDs controlled by %s", controller.Name,
@@ -149,7 +149,7 @@ func (c *Client) GetAllNetworks(
 
 func (c *Client) getNetworkFromCache(id string) (*zerotier.ControllerNetwork, bool) {
 	network, cacheHit, err := c.Cache.GetNetworkByID(id)
-	if err != nil && err != context.Canceled && errors.Unwrap(err) != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		// Log the error but return as a cache miss so we can manually query the network
 		c.Logger.Error(errors.Wrapf(err, "couldn't get the cache entry for the network with id %s", id))
 		return nil, false // treat an unparseable cache entry like a cache miss

--- a/internal/clients/ztcontrollers/controllers.go
+++ b/internal/clients/ztcontrollers/controllers.go
@@ -117,7 +117,7 @@ func (c *Client) checkCachedController(ctx context.Context, address string) (*Co
 
 func (c *Client) FindControllerByAddress(ctx context.Context, address string) (*Controller, error) {
 	controller, err := c.checkCachedController(ctx, address)
-	if err != nil && err != context.Canceled && errors.Unwrap(err) != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		// Log the error and proceed to manually query all controllers
 		c.Logger.Error(err, errors.Wrapf(
 			err, "couldn't handle the cache entry for the zerotier controller with address %s", address,
@@ -153,7 +153,7 @@ func (c *Client) FindControllerByAddress(ctx context.Context, address string) (*
 
 func (c *Client) getAddressFromCache(controller Controller) (string, bool) {
 	address, cacheHit, err := c.Cache.GetAddressByServer(controller.Server)
-	if err != nil && err != context.Canceled && errors.Unwrap(err) != context.Canceled {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		// Log the error but return as a cache miss so we can manually query the controller
 		c.Logger.Error(errors.Wrapf(
 			err, "couldn't get the cache entry for the Zerotier address for %s", controller.Server,

--- a/pkg/godest/actioncable/connections.go
+++ b/pkg/godest/actioncable/connections.go
@@ -122,7 +122,7 @@ func defaultErrorSanitizer(err error) string {
 		return ""
 	}
 
-	if err == context.Canceled || errors.Unwrap(err) == context.Canceled {
+	if errors.Is(err, context.Canceled) {
 		return "logged out"
 	}
 	// Sanitize the error message to avoid leaking information from Serve method errors

--- a/pkg/godest/turbostreams/broker.go
+++ b/pkg/godest/turbostreams/broker.go
@@ -144,7 +144,7 @@ func (b *Broker) subHandler(sessionID string) SubHandler {
 		c.sessionID = sessionID
 		h := b.getHandler(MethodSub, topic, c)
 		err := errors.Wrapf(h(c), "turbo streams not subscribable on topic %s", topic)
-		if err != nil {
+		if err != nil && !errors.Is(err, stdContext.Canceled) {
 			b.logger.Error(err)
 		}
 		return err
@@ -158,7 +158,7 @@ func (b *Broker) unsubHandler(sessionID string) UnsubHandler {
 		c.sessionID = sessionID
 		h := b.getHandler(MethodUnsub, topic, c)
 		err := errors.Wrapf(h(c), "turbo streams not unsubscribable on topic %s", topic)
-		if err != nil {
+		if err != nil && !errors.Is(err, stdContext.Canceled) {
 			b.logger.Error(err)
 		}
 	}
@@ -173,7 +173,7 @@ func (b *Broker) msgHandler(sessionID string) MsgHandler {
 		c.rendered = &bytes.Buffer{}
 		h := b.getHandler(MethodMsg, topic, c)
 		err = errors.Wrapf(h(c), "turbo streams message not processable on topic %s", topic)
-		if err != nil {
+		if err != nil && !errors.Is(err, stdContext.Canceled) {
 			b.logger.Error(err)
 			return "", err
 		}
@@ -191,7 +191,7 @@ func (b *Broker) startPub(ctx stdContext.Context, topic string) {
 	h := b.getHandler(MethodPub, topic, c)
 	go func() {
 		err := h(c)
-		if err != nil && err != stdContext.Canceled && errors.Unwrap(err) != stdContext.Canceled {
+		if err != nil && !errors.Is(err, stdContext.Canceled) {
 			b.logger.Error(err)
 		}
 	}()


### PR DESCRIPTION
This PR prevents logging of context cancelation errors in some more places in the Turbo Streams Broker.