### PR TITLE
Handle DNS-named networks with unknown controllers, rather than 404'ing

### DIFF
--- a/internal/app/fluitans/client/networks.go
+++ b/internal/app/fluitans/client/networks.go
@@ -34,7 +34,8 @@ func GetNetworks(
 				address := ztc.GetControllerAddress(id)
 				controller, err := cc.FindControllerByAddress(ctx, address)
 				if err != nil {
-					return err
+					// Tolerate unknown controllers by acting as if they (and their networks) don't exist
+					return nil
 				}
 				controllers[i] = controller
 


### PR DESCRIPTION
This PR fixes fluitans's functionality for looking up Zerotier networks from DNS records by allowing it to tolerate DNS records naming uncontrolled networks (i.e. networks without known controllers). Previously, fluitans would return a 404 on when attempting to display any network if desec returned any DNS record naming any uncontrolled network, and it would return a 404 on the DNS info page. Now, it ignores those unknown networks for displaying other networks, and it displays uncontrolled networks as unknown networks on the DNS info page.