### PR TITLE
Fix cumulative layout shift in navbar by adding img width/height

### DIFF
--- a/web/app/package.json
+++ b/web/app/package.json
@@ -13,7 +13,7 @@
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-node-resolve": "^14.1.0",
     "@rollup/plugin-replace": "^4.0.0",
-    "@sargassum-world/styles": "^0.2.0",
+    "@sargassum-world/styles": "^0.2.2",
     "bulma": "^0.9.4",
     "eslint": "^8.23.1",
     "eslint-plugin-import": "^2.24.2",

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -208,10 +208,10 @@
     "@rails/actioncable" "^7.0.3-1"
     async-mutex "^0.3.2"
 
-"@sargassum-world/styles@^0.2.0":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@sargassum-world/styles/-/styles-0.2.1.tgz#91394ad6900a3b6648c5b8173e85b76cf9713ee2"
-  integrity sha512-3wXDXRI1hiDi0lfzIIFl2VllQ+HF5LrzOrfAuiLTWqbTPfc1vLaKj7W0VjjWeM8klf5rwZ37CURs4cB/1XQ9Xw==
+"@sargassum-world/styles@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@sargassum-world/styles/-/styles-0.2.2.tgz#3df48dff01ec1691f0c8f68326480a4e9471cede"
+  integrity sha512-Oxc3PrkVEB29LzqpbxfzyRKKkhnK8USHdC5VeQe2na9/6ImKBxOJT6Y0Zv34njnL3XUboDvyTjKZQ6sEdpZ2fA==
 
 "@types/estree@*":
   version "0.0.51"

--- a/web/templates/shared/nav/navbar.partial.tmpl
+++ b/web/templates/shared/nav/navbar.partial.tmpl
@@ -20,6 +20,7 @@
     id="navbar-brand-logo"
     class="navbar-brand-logo"
     src="{{staticHashed "logo.svg"}}"
+    width="32" height="32"
     alt="Fluitans logo"
   />
   Fluitans
@@ -136,7 +137,11 @@
               aria-label="Toggle theme"
             >
               <span class="icon is-small">
-                <img src="{{staticHashed "icons/white-balance-sunny.svg"}}" alt="Toggle theme">
+                <img
+                src="{{staticHashed "icons/white-balance-sunny.svg"}}"
+                width="32" height="32"
+                alt="Toggle theme"
+              >
               </span>
             </button>
           </div>


### PR DESCRIPTION
This PR fixes an issue reported by [WebPageTest](https://www.webpagetest.org/) about layout shifts caused by missing `width` and `height` attributes on image tags for the logo and the theme toggle icon. A test report reporting these issues can be seen here: https://www.webpagetest.org/result/220923_AiDc3G_F1V/3/experiments/#Usable ; and a test report with the changes made in this PR can be seen here: https://www.webpagetest.org/result/220923_BiDcYA_F6X/3/experiments/#Usable . This fix heavily relies on changes made in [sargassum-world/styles v0.2.2](https://github.com/sargassum-world/styles/commit/a623b89965b2e16cd9f788bfa541b5a69498e448#diff-290a64ea3088c73460c687267658452913430f7092f02907a7f8b01080729695).